### PR TITLE
fix: broken link in Identity Proofs (DNS-TXT ADR)

### DIFF
--- a/docs/extension/identity-proofs.md
+++ b/docs/extension/identity-proofs.md
@@ -22,13 +22,13 @@ Only domain name owners (and the registrar that they trust) have the authority t
 
 In an OpenAttestation DNS-TXT identity proof, we record a Document Store address and the network (e.g Ethereum, Main Net) it is on. In the OpenAttestation document itself, we declare the domain name to search for the record as well as the Document Store Ethereum address. This forms a bi-directional trust assertion, and if the Document's cryptographic proof is issued on that Document Store - we can say that the domain name owner has endorsed the issuance of this document.
 
-A deeper technical discussion of this topic can be found at [OpenCerts 2.0 DNS-TXT Architecture Decision Record](OpenCerts 2.0 DNS-TXT Architecture Decision Record)
+A deeper technical discussion of this topic can be found at [OpenAttestation's Decentralised Identity Proof using DNS-TXT Architecture Decision Record](https://github.com/Open-Attestation/adr/blob/master/decentralized_identity_proof_DNS-TXT.md).
 
 ## How to create DNS TXT Record
 
 As an issuer, you will need to add a DNS TXT record to your domain name. The exact steps to achieve this can be confirmed with your domain name registrar, this is usually achieved through your domain administration web UI.
 
-The following is an example for an issuer
+The following is an example for an issuer:
 1. on `Ethereum Main Net`
 1. has a Document Store address of `0x9178F546D3FF57D7A6352bD61B80cCCD46199C2d`
 ```text


### PR DESCRIPTION
I believe there's supposed to be a link to the DNS-TXT ADR but seems to be broken, it's fixed now and pointed towards https://github.com/Open-Attestation/adr/blob/master/decentralized_identity_proof_DNS-TXT.md