### PR TITLE
chore: updated docs and formatting

### DIFF
--- a/docs/appendix/glossary.md
+++ b/docs/appendix/glossary.md
@@ -8,7 +8,7 @@ This page details the terminologies commonly used in the documentation.
 
 ### Ether
 
-Ether is the cryptocurrency used in the Ethereum blockchain network. Ethers are used to create and interact with smart contracts. They can be either be mined or bought via fiat currency (e.g. Singapore Dollars).
+Ether is the cryptocurrency used in the Ethereum blockchain network. Ethers are used to create and interact with smart contracts. They can either be mined or bought via fiat currency (e.g. Singapore Dollars).
 
 ### Sign
 

--- a/docs/appendix/glossary.md
+++ b/docs/appendix/glossary.md
@@ -1,0 +1,32 @@
+---
+id: glossary
+title: Glossary
+sidebar_label: Glossary
+---
+
+This page details the terminologies commonly used in the documentation.
+
+### Ether
+
+Ether is the cryptocurrency used in the Ethereum blockchain network. Ethers are used to create and interact with smart contracts. They can be either be mined or bought via fiat currency (e.g. Singapore Dollars).
+
+### Sign
+
+Placeholder
+
+### Signature
+
+Placeholder
+
+### Smart contract
+
+Placeholder
+
+### Document store
+
+A document store is a smart contract on the Ethereum network that records the issuance and revocation status of OA documents. The document store allows the owner to perform the following actions:
+
+- issue new OA documents
+- revoke an existing OA document
+- check for the validity of an OA document
+- transferring the document store to another owner

--- a/docs/appendix/glossary.md
+++ b/docs/appendix/glossary.md
@@ -24,7 +24,7 @@ Placeholder
 
 ### Document store
 
-A document store is a smart contract on the Ethereum network that records the issuance and revocation status of OA documents. The document store allows the owner to perform the following actions:
+A document store is a smart contract on the Ethereum network that records the issuance and revocation status of OpenAttestation (OA) documents. The document store allows the owner to perform the following actions:
 
 - issue new OA documents
 - revoke an existing OA document

--- a/docs/verifiable-document/dns-proof.md
+++ b/docs/verifiable-document/dns-proof.md
@@ -49,6 +49,7 @@ The `netId` corresponds to the [network ID for the different Ethereum networks](
 |--------------|--------------------------|-----------|
 | `1`          | Ethereum Mainnet         | `mainnet` |
 | `3`          | Ethereum Testnet Ropsten | `ropsten` |
+| `4`          | Ethereum Testnet Rinkeby | `rinkeby` |
 
 For more information on switching to production mode, refer to the [Additional Note for Identity Proof in Production](#additional-note-for-identity-proof-in-production) section below.
 

--- a/docs/verifiable-document/dns-proof.md
+++ b/docs/verifiable-document/dns-proof.md
@@ -62,11 +62,11 @@ The `TXT` record above is for use for documents issued on the Ethereum `ropsten`
 | `1`          | Ethereum Mainnet         | `mainnet` |
 | `3`          | Ethereum Testnet Ropsten | `ropsten` |
 
-An example of a valid `TXT` record for Ethereum mainnet is as shown:
+In other words, an example of a valid `TXT` record for Ethereum `mainnet` network means changing the `netId` to `1`:
 
 | Type  | Name                       | Value                                                         |
 |-------|----------------------------|---------------------------------------------------------------|
-| `TXT` | `demo.openattestation.com` | `openatts net=ethereum netId=1 addr=0x9db35C07350e9a16C828dAda37fd9c2923c75812` |
+| TXT   | demo.openattestation.com   | openatts net=ethereum netId=1 addr=0x9db35C07350e9a16C828dAda37fd9c2923c75812 |
 
 ## Additional Note for Adding DNS `TXT` Records
 

--- a/docs/verifiable-document/dns-proof.md
+++ b/docs/verifiable-document/dns-proof.md
@@ -12,52 +12,70 @@ In this guide, we will bind the document issuer's identity to a valid domain nam
 
 ![Example Issuer Identity](/docs/verifiable-document/dns-proof/example.png)
 
-In this example, the document's issuer is bound to `DEMO.OPENATTESTATION.COM`.
+In this example, the document's issuer is bound to `demo.openattestation.com`.
 
-## Pre-requisite
+## Prerequisites
 
-- Domain Name
+- Domain name
+- Edit access to your domain's DNS records
 
 To bind the domain name to the issuer's identity, you must be able to change the DNS record of the domain name.
 
 ## Inserting the DNS Record
 
-You will need to add a DNS TXT record to your domain name. The exact steps to achieve this can be confirmed with your domain name registrar, this is usually achieved through your domain administration web UI.
+You will need to add a DNS `TXT` record to your domain name. The exact steps to achieve this can be confirmed with your domain registrar, this is usually achieved through your domain registrar or DNS provider's web UI.
 
-Select a domain name that you will like to associate with your documents. The domain can either be the root domain (ie. openattestation.com) or a subdomain (ie issuer.openattestation.com). Using the root domain will be recommended as it will be easier for viewers of your documents to recognize.
+> While we have provided [links to guides](#additional-note-for-adding-DNS-TXT-records) on adding DNS `TXT` records for some common domain registrars and DNS providers, the steps below is a generic procedure for any DNS provider.
 
-Using the domain web UI, insert a `TXT` record into the DNS in the following format:
+Select a domain name that you will like to associate with your documents. The domain can either be the root domain (e.g. `openattestation.com`) or a subdomain (e.g. `issuer.openattestation.com`). Using the root domain is recommended as it will be easier for viewers of your documents to recognize visually, as shown in the [example](#example) above.
 
-```text
-openatts net=ethereum netId=3 addr=&lt;DOCUMENT_STORE_ADDRESS&gt;
-```
+Within your domain registrar or DNS provider's web UI, insert a `TXT` record into the DNS in the following format:
 
-where `<DOCUMENT_STORE_ADDRESS>` is the document store smart contract address obtained [in the previous guide](/docs/verifiable-document/document-store/).
+| Type  | Name                  | Value                                                         |
+|-------|-----------------------|---------------------------------------------------------------|
+| `TXT` | `openattestation.com` | `openatts net=ethereum netId=3 addr=<DOCUMENT_STORE_ADDRESS>` |
+
+The `<DOCUMENT_STORE_ADDRESS>` in the `Value` field above is the document store smart contract address obtained [in the previous guide](/docs/verifiable-document/document-store/).
 
 An example of a valid `TXT` record is as shown:
 
-```text
-openatts net=ethereum netId=3 addr=0x9db35C07350e9a16C828dAda37fd9c2923c75812
-```
+| Type  | Name                       | Value                                                         |
+|-------|----------------------------|---------------------------------------------------------------|
+| `TXT` | `demo.openattestation.com` | `openatts net=ethereum netId=3 addr=0x9db35C07350e9a16C828dAda37fd9c2923c75812` |
 
 ## Testing the DNS Record
 
 ![Google DNS to Test](/docs/verifiable-document/dns-proof/google-dns.png)
 
-> After the update, you may need to wait up to 24 hrs for the DNS to propagate. You may continue with the other parts of the guide while waiting for DNS to propagate.
+> After the update, you may need to wait up to 24 hours for the DNS to propagate. You may continue with the other parts of the guide while waiting for DNS to propagate.
 
-After adding the `TXT`record, you may check that the record has been inserted correctly by viewing with https://dns.google.com/.
+After adding the `TXT` record, you may want to check that the record has been inserted correctly by viewing with [Google DNS](https://dns.google.com/).
 
-Make sure to select `TXT` in the "RR Type" dropdown.
+Make sure to select `TXT` in the `RR Type` dropdown.
 
 ## Additional Note for Identity Proof in Production
 
-The `TXT` record above is for use for documents issued on the `ropsten` network. To bind the identity in production where your documents are issued in the Ethereum main net, you will have to change `netId` to `1`.
+The `TXT` record above is for use for documents issued on the Ethereum `ropsten` network. To bind the identity in production where your documents are issued in the Ethereum mainnet, you will have to change `netId` to `1`. The `netId` corresponds to the [network ID for the different Ethereum networks](https://chainid.network/).
 
-The `netId` corresponds to the [network ID for the different Ethereum networks](https://ethereum.stackexchange.com/questions/17051/how-to-select-a-network-id-or-is-there-a-list-of-network-ids).
+Throughout our documentation, we generally use only the following networks:
 
-An example of a valid `TXT` record for Ethereum main network is as shown:
+| Network ID   | Name                     | Network   |
+|--------------|--------------------------|-----------|
+| `1`          | Ethereum Mainnet         | `mainnet` |
+| `3`          | Ethereum Testnet Ropsten | `ropsten` |
 
-```text
-openatts net=ethereum netId=1 addr=0x9db35C07350e9a16C828dAda37fd9c2923c75812
-```
+An example of a valid `TXT` record for Ethereum mainnet is as shown:
+
+| Type  | Name                       | Value                                                         |
+|-------|----------------------------|---------------------------------------------------------------|
+| `TXT` | `demo.openattestation.com` | `openatts net=ethereum netId=1 addr=0x9db35C07350e9a16C828dAda37fd9c2923c75812` |
+
+## Additional Note for Adding DNS `TXT` Records
+
+Below is a list of guides provided by some of the common domain registrars and DNS providers. This list is by no means comprehensive.
+
+- [Amazon Route 53](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/dns-txt-records.html)
+- [Cloudflare](https://support.cloudflare.com/hc/en-us/articles/360019093151-Managing-DNS-records-in-Cloudflare)
+- [Name.com](https://www.name.com/support/articles/115004972547-Adding-a-TXT-Record)
+- [Namecheap](https://www.namecheap.com/support/knowledgebase/article.aspx/317/2237/how-do-i-add-txtspfdkimdmarc-records-for-my-domain)
+- [GoDaddy](https://sg.godaddy.com/help/add-a-txt-record-19232)

--- a/docs/verifiable-document/dns-proof.md
+++ b/docs/verifiable-document/dns-proof.md
@@ -4,9 +4,9 @@ title: Configuring DNS
 sidebar_label: Configuring DNS
 ---
 
-Every OA document's provenance can be verified and traced back to its creator or issuer. This is achieved by embedding an `identityProof` in the document which serves as a claim for identity. During the verification phase, the claim is checked against external records.
+Every OA document's provenance can be verified and traced back to its creator or issuer. This is achieved by embedding an `identityProof` property in the document, which serves as a claim for identity. During the verification phase, the claim is checked against external records.
 
-In this guide, we will bind the document issuer's identity to a valid domain name. This domain will be displayed as issuer every time the document is rendered in a compliant viewer.
+In this guide, we will bind the document issuer's identity to a valid domain name. This domain will be displayed as issuer every time the document is rendered in an OA-compliant decentralized renderer.
 
 ## Example
 
@@ -27,13 +27,15 @@ You will need to add a DNS `TXT` record to your domain name. The exact steps to 
 
 > While we have provided [links to guides](#additional-note-for-adding-DNS-TXT-records) on adding DNS `TXT` records for some common domain registrars and DNS providers, the steps below is a generic procedure for any DNS provider.
 
-Select a domain name that you will like to associate with your documents. The domain can either be the root domain (e.g. `openattestation.com`) or a subdomain (e.g. `issuer.openattestation.com`). Using the root domain is recommended as it will be easier for viewers of your documents to recognize visually, as shown in the [example](#example) above.
+Select a domain name that you will like to associate with your documents. The domain can either be the root domain (e.g. `openattestation.com`) or a subdomain (e.g. `issuer.openattestation.com`). Using the root domain is recommended as it will be easier for viewers of your documents to recognize visually.
 
 Within your domain registrar or DNS provider's web UI, insert a `TXT` record into the DNS in the following format:
 
 | Type  | Name                  | Value                                                         |
 |-------|-----------------------|---------------------------------------------------------------|
-| `TXT` | `openattestation.com` | `openatts net=ethereum netId=3 addr=<DOCUMENT_STORE_ADDRESS>` |
+| TXT | openattestation.com | openatts net=ethereum netId=3 addr=`<DOCUMENT_STORE_ADDRESS>` |
+
+> The document store address needs to be prepended with `addr`.
 
 The `<DOCUMENT_STORE_ADDRESS>` in the `Value` field above is the document store smart contract address obtained [in the previous guide](/docs/verifiable-document/document-store/).
 
@@ -41,17 +43,15 @@ An example of a valid `TXT` record is as shown:
 
 | Type  | Name                       | Value                                                         |
 |-------|----------------------------|---------------------------------------------------------------|
-| `TXT` | `demo.openattestation.com` | `openatts net=ethereum netId=3 addr=0x9db35C07350e9a16C828dAda37fd9c2923c75812` |
+| TXT | demo.openattestation.com | openatts net=ethereum netId=3 addr=0xED2E50434Ac3623bAD763a35213DAD79b43208E4 |
 
 ## Testing the DNS Record
 
 ![Google DNS to Test](/docs/verifiable-document/dns-proof/google-dns.png)
 
-> After the update, you may need to wait up to 24 hours for the DNS to propagate. You may continue with the other parts of the guide while waiting for DNS to propagate.
+> The DNS propagation should take a few minutes, though in some cases you may need to wait up to 24 hours. Continue with the other parts of the guide while waiting for DNS to propagate.
 
-After adding the `TXT` record, you may want to check that the record has been inserted correctly by viewing with [Google DNS](https://dns.google.com/).
-
-Make sure to select `TXT` in the `RR Type` dropdown.
+After adding the `TXT` record, we recommend you to check that the record has been inserted correctly by viewing with [Google DNS](https://dns.google.com/). Make sure to select `TXT` in the `RR Type` dropdown.
 
 ## Additional Note for Identity Proof in Production
 

--- a/docs/verifiable-document/dns-proof.md
+++ b/docs/verifiable-document/dns-proof.md
@@ -35,15 +35,22 @@ Within your domain registrar or DNS provider's web UI, insert a `TXT` record int
 |-------|-------------|---------------------------------------------------------------|
 | TXT   | example.com | openatts net=ethereum netId=3 addr=`<DOCUMENT_STORE_ADDRESS>` |
 
-> The document store address needs to be prepended with `addr`.
-
-The `<DOCUMENT_STORE_ADDRESS>` in the `Value` field above is the document store smart contract address obtained [in the previous guide](/docs/verifiable-document/document-store/).
+The `<DOCUMENT_STORE_ADDRESS>` in the `Value` field above is the document store smart contract address obtained [in the previous guide](/docs/verifiable-document/document-store/). Please note that the document store address needs to be prepended with `addr`.
 
 An example of a valid DNS `TXT` record is as shown:
 
 | Type  | Name                       | Value                                                         |
 |-------|----------------------------|---------------------------------------------------------------|
 | TXT | demo.openattestation.com | openatts net=ethereum netId=3 addr=0xED2E50434Ac3623bAD763a35213DAD79b43208E4 |
+
+The `netId` corresponds to the [network ID for the different Ethereum networks](https://chainid.network/). We generally use only the following networks:
+
+| Network ID   | Name                     | Network   |
+|--------------|--------------------------|-----------|
+| `1`          | Ethereum Mainnet         | `mainnet` |
+| `3`          | Ethereum Testnet Ropsten | `ropsten` |
+
+For more information on switching to production mode, refer to the [Additional Note for Identity Proof in Production](#additional-note-for-identity-proof-in-production) section below.
 
 ## Testing the DNS Record
 
@@ -55,14 +62,9 @@ After adding the `TXT` record, we recommend you to check that the record has bee
 
 ## Additional Note for Identity Proof in Production
 
-The `TXT` record above is for use for documents issued on the Ethereum `ropsten` network. To bind the identity in production where your documents are issued in the Ethereum `mainnet` network, you will have to change `netId` to `1`. The `netId` corresponds to the [network ID for the different Ethereum networks](https://chainid.network/). We generally use only the following networks:
+The `TXT` record above is for use for documents issued on the Ethereum `ropsten` network. To bind the identity in production where your documents are issued in the Ethereum `mainnet` network, you will have to change `netId` to `1`.
 
-| Network ID   | Name                     | Network   |
-|--------------|--------------------------|-----------|
-| `1`          | Ethereum Mainnet         | `mainnet` |
-| `3`          | Ethereum Testnet Ropsten | `ropsten` |
-
-In other words, an example of a valid `TXT` record for Ethereum `mainnet` network means changing the `netId` to `1`:
+An example of a valid `TXT` record for Ethereum `mainnet` network is as shown:
 
 | Type  | Name                       | Value                                                         |
 |-------|----------------------------|---------------------------------------------------------------|

--- a/docs/verifiable-document/dns-proof.md
+++ b/docs/verifiable-document/dns-proof.md
@@ -25,21 +25,21 @@ To bind the domain name to the issuer's identity, you must be able to change the
 
 You will need to add a DNS `TXT` record to your domain name. The exact steps to achieve this can be confirmed with your domain registrar, this is usually achieved through your domain registrar or DNS provider's web UI.
 
-> While we have provided [links to guides](#additional-note-for-adding-DNS-TXT-records) on adding DNS `TXT` records for some common domain registrars and DNS providers, the steps below is a generic procedure for any DNS provider.
+While we have provided [links to guides](#additional-note-for-adding-dns-txt-records) on adding DNS `TXT` records for some common domain registrars and DNS providers, the steps below is a generic procedure for any DNS provider.
 
 Select a domain name that you will like to associate with your documents. The domain can either be the root domain (e.g. `openattestation.com`) or a subdomain (e.g. `issuer.openattestation.com`). Using the root domain is recommended as it will be easier for viewers of your documents to recognize visually.
 
 Within your domain registrar or DNS provider's web UI, insert a `TXT` record into the DNS in the following format:
 
-| Type  | Name                  | Value                                                         |
-|-------|-----------------------|---------------------------------------------------------------|
-| TXT | openattestation.com | openatts net=ethereum netId=3 addr=`<DOCUMENT_STORE_ADDRESS>` |
+| Type  | Name        | Value                                                         |
+|-------|-------------|---------------------------------------------------------------|
+| TXT   | example.com | openatts net=ethereum netId=3 addr=`<DOCUMENT_STORE_ADDRESS>` |
 
 > The document store address needs to be prepended with `addr`.
 
 The `<DOCUMENT_STORE_ADDRESS>` in the `Value` field above is the document store smart contract address obtained [in the previous guide](/docs/verifiable-document/document-store/).
 
-An example of a valid `TXT` record is as shown:
+An example of a valid DNS `TXT` record is as shown:
 
 | Type  | Name                       | Value                                                         |
 |-------|----------------------------|---------------------------------------------------------------|
@@ -51,13 +51,11 @@ An example of a valid `TXT` record is as shown:
 
 > The DNS propagation should take a few minutes, though in some cases you may need to wait up to 24 hours. Continue with the other parts of the guide while waiting for DNS to propagate.
 
-After adding the `TXT` record, we recommend you to check that the record has been inserted correctly by viewing with [Google DNS](https://dns.google.com/). Make sure to select `TXT` in the `RR Type` dropdown.
+After adding the `TXT` record, we recommend you to check that the record has been inserted correctly by viewing with [Google DNS](https://dns.google.com/). Make sure to select `TXT` in the _RR Type_ dropdown.
 
 ## Additional Note for Identity Proof in Production
 
-The `TXT` record above is for use for documents issued on the Ethereum `ropsten` network. To bind the identity in production where your documents are issued in the Ethereum mainnet, you will have to change `netId` to `1`. The `netId` corresponds to the [network ID for the different Ethereum networks](https://chainid.network/).
-
-Throughout our documentation, we generally use only the following networks:
+The `TXT` record above is for use for documents issued on the Ethereum `ropsten` network. To bind the identity in production where your documents are issued in the Ethereum `mainnet` network, you will have to change `netId` to `1`. The `netId` corresponds to the [network ID for the different Ethereum networks](https://chainid.network/). We generally use only the following networks:
 
 | Network ID   | Name                     | Network   |
 |--------------|--------------------------|-----------|

--- a/docs/verifiable-document/document-store.md
+++ b/docs/verifiable-document/document-store.md
@@ -6,12 +6,12 @@ sidebar_label: Deploying Document Store
 
 The document store is a smart contract on the Ethereum network that records the issuance and revocation status of OA documents. In this guide, we will deploy a document store smart contract on the Ethereum `ropsten` network which is a test network that does not require actual ethers for transactions.
 
-## Pre-requisite
+## Prerequisites
 
 - Chrome browser
 - Metamask setup
 
-A guide to setting up metamask is available in ["Test Account Setup"](/docs/appendix/ropsten-setup) in the appendix.
+A guide to setting up Metamask is available in [Test Account Setup](/docs/appendix/ropsten-setup) section in the appendix.
 
 ## Deploying via Web Application
 
@@ -23,30 +23,30 @@ We have provided a web interface to deploy the document store smart contract at 
 
 ![Connecting Metamask to Ropsten](/docs/verifiable-document/document-store/ropsten.png)
 
-Connect metamask to the `ropsten` network by selecting "Ropsten Test Network" in the chrome plugin's header. You may be asked to log in at this step if you have not done so.
+Connect metamask to the `ropsten` network by selecting `Ropsten Test Network` in the Chrome plugin's header. You may be asked to log in at this step if you have not done so.
 
 ### 2. Connect Metamask to Web Application
 
 ![Admin Interface](/docs/verifiable-document/document-store/interface.png)
 
-To interact with the decentralize application (Dapp), you will need to connect your metamask wallet to the webpage. Select "Metamask" on the web app to connect the Dapp to your wallet provider, metamask.
+To interact with the decentralized application (Dapp), you will need to connect your Metamask wallet to the webpage. Select `Metamask` on the web app to connect the Dapp to your wallet provider, Metamask.
 
 ![Metamask Connection Request](/docs/verifiable-document/document-store/connection-request.png)
 
-Click on "Connect" to allow the web app to interact with metamask wallet.
+Click on `Connect` to allow the web app to interact with Metamask wallet.
 
 ### 3. Deploying Document Store Smart Contract
 
 ![Filling in Organization name](/docs/verifiable-document/document-store/deploy.png)
 
-You may enter your organization name as the "Issuer Name" and click "Deploy" to deploy the smart contract.
+You may enter your organization name as the `Issuer Name` and click `Deploy` to deploy the smart contract.
 
 ![Confirming Transaction](/docs/verifiable-document/document-store/confirmation.png)
 
-After clicking on "Deploy", you will be asked to confirm the transaction in a separate popup. Click "Confirm" to continue.
+After clicking on `Deploy`, you will be asked to confirm the transaction in a separate popup. Click `Confirm` to continue.
 
 ![Successful deployment](/docs/verifiable-document/document-store/success.png)
 
-Once your document store smart contract has been successfully deployed, you will see the success message with the `Store Address`.
+Once your document store smart contract has been successfully deployed, you will see the success message with the `Store Address` (`0xED2E50434Ac3623bAD763a35213DAD79b43208E4` in the example above).
 
 > Save this value for future reference.

--- a/docs/verifiable-document/document-store.md
+++ b/docs/verifiable-document/document-store.md
@@ -4,7 +4,7 @@ title: Deploying Document Store Smart Contract
 sidebar_label: Deploying Document Store
 ---
 
-The document store is a smart contract on the Ethereum network that records the issuance and revocation status of OA documents. In this guide, we will deploy a document store smart contract on the Ethereum `ropsten` network, which is a test network that does not require actual [ethers] for transactions.
+The document store is a smart contract on the Ethereum network that records the issuance and revocation status of OA documents. In this guide, we will deploy a document store smart contract on the Ethereum `ropsten` network, which is a test network that does not require actual [ethers](/docs/appendix/glossary#ether) for transactions.
 
 ## Prerequisites
 
@@ -18,9 +18,7 @@ Currently, we provide two ways of deploying the document store smart contract on
 - [TradeTrust Admin Portal](https://admin.tradetrust.io/), a web app
 - [Open Attestation CLI](https://github.com/Open-Attestation/open-attestation-cli), a command line tool
 
-They are both decentralized apps (Dapps) as both enable you to interact with smart contracts on the Ethereum blockchain.
-
-In this guide however, we will only be using the web app since it provides a no-code option to deploy the document store.
+They are both decentralized apps (Dapps) as both enable you to interact with smart contracts on the Ethereum blockchain. In this guide however, we will only be using the TradeTrust Admin Portal since it provides a no-code option to deploy the document store.
 
 ![Admin Interface](/docs/verifiable-document/document-store/interface.png)
 
@@ -52,6 +50,6 @@ After clicking on _Deploy_, you will be asked to confirm the transaction in a se
 
 ![Successful deployment](/docs/verifiable-document/document-store/success.png)
 
-Once your document store smart contract has been successfully deployed, you will see the success message with the document store address. In the example above, the document store address is `0xED2E50434Ac3623bAD763a35213DAD79b43208E4` and is **NOT** the Transaction ID.
+Once your document store smart contract has been successfully deployed, you will see the success message with the document store address. In the example above, the document store address is `0xED2E50434Ac3623bAD763a35213DAD79b43208E4`, please do **NOT** use the Transaction ID.
 
-**Please save this address in your notepad as the web app does not keep track of your document store addresses.** You will need this address to complete the tutorial.
+**Save the document store address in your notepad as the web app does not keep track of your document store addresses.** You will need this address to complete the tutorial.

--- a/docs/verifiable-document/document-store.md
+++ b/docs/verifiable-document/document-store.md
@@ -4,49 +4,54 @@ title: Deploying Document Store Smart Contract
 sidebar_label: Deploying Document Store
 ---
 
-The document store is a smart contract on the Ethereum network that records the issuance and revocation status of OA documents. In this guide, we will deploy a document store smart contract on the Ethereum `ropsten` network which is a test network that does not require actual ethers for transactions.
+The document store is a smart contract on the Ethereum network that records the issuance and revocation status of OA documents. In this guide, we will deploy a document store smart contract on the Ethereum `ropsten` network, which is a test network that does not require actual [ethers] for transactions.
 
 ## Prerequisites
 
-- Chrome browser
-- Metamask setup
+- Google Chrome web browser
+- Metamask setup, refer to the [Test Account Setup](/docs/appendix/ropsten-setup) section for the setup guide
 
-A guide to setting up Metamask is available in [Test Account Setup](/docs/appendix/ropsten-setup) section in the appendix.
+## Deployment Methods
 
-## Deploying via Web Application
+Currently, we provide two ways of deploying the document store smart contract onto Ethereum:
+
+- [TradeTrust Admin Portal](https://admin.tradetrust.io/), a web app
+- [Open Attestation CLI](https://github.com/Open-Attestation/open-attestation-cli), a command line tool
+
+They are both decentralized apps (Dapps) as both enable you to interact with smart contracts on the Ethereum blockchain.
+
+In this guide however, we will only be using the web app since it provides a no-code option to deploy the document store.
 
 ![Admin Interface](/docs/verifiable-document/document-store/interface.png)
 
-We have provided a web interface to deploy the document store smart contract at https://admin.tradetrust.io/.
-
-### 1. Change Metamask Network to Ropsten
+### Change Metamask Network to Ropsten
 
 ![Connecting Metamask to Ropsten](/docs/verifiable-document/document-store/ropsten.png)
 
-Connect metamask to the `ropsten` network by selecting `Ropsten Test Network` in the Chrome plugin's header. You may be asked to log in at this step if you have not done so.
+Connect Metamask to the Ethereum `ropsten` network by selecting _Ropsten Test Network_ in the Google Chrome plugin's header. You may be asked to log in at this step if you have not done so.
 
-### 2. Connect Metamask to Web Application
+### Connect Metamask to Web App
 
 ![Admin Interface](/docs/verifiable-document/document-store/interface.png)
 
-To interact with the decentralized application (Dapp), you will need to connect your Metamask wallet to the webpage. Select `Metamask` on the web app to connect the Dapp to your wallet provider, Metamask.
+To interact with the TradeTrust Admin Portal web app, you will need to connect your Metamask wallet. Select _Metamask_ on the web app to connect it to your Metamask wallet.
 
 ![Metamask Connection Request](/docs/verifiable-document/document-store/connection-request.png)
 
-Click on `Connect` to allow the web app to interact with Metamask wallet.
+Click on _Connect_ to allow the web app to interact with Metamask wallet.
 
-### 3. Deploying Document Store Smart Contract
+### Deploying Document Store Smart Contract
 
 ![Filling in Organization name](/docs/verifiable-document/document-store/deploy.png)
 
-You may enter your organization name as the `Issuer Name` and click `Deploy` to deploy the smart contract.
+Enter your organization name as the _Issuer Name_ and click _Deploy_ to deploy the document store as an Ethereum smart contract.
 
 ![Confirming Transaction](/docs/verifiable-document/document-store/confirmation.png)
 
-After clicking on `Deploy`, you will be asked to confirm the transaction in a separate popup. Click `Confirm` to continue.
+After clicking on _Deploy_, you will be asked to confirm the transaction in a separate popup. Click _Confirm_ to continue.
 
 ![Successful deployment](/docs/verifiable-document/document-store/success.png)
 
-Once your document store smart contract has been successfully deployed, you will see the success message with the `Store Address` (`0xED2E50434Ac3623bAD763a35213DAD79b43208E4` in the example above).
+Once your document store smart contract has been successfully deployed, you will see the success message with the document store address. In the example above, the document store address is `0xED2E50434Ac3623bAD763a35213DAD79b43208E4` and is **NOT** the Transaction ID.
 
-> Save this value for future reference.
+**Please save this address in your notepad as the web app does not keep track of your document store addresses.** You will need this address to complete the tutorial.

--- a/docs/verifiable-document/document-template.md
+++ b/docs/verifiable-document/document-template.md
@@ -4,23 +4,23 @@ title: Deploying Document Renderer
 sidebar_label: Deploying Document Renderer
 ---
 
-OA documents are both readable by machines as well as by humans. Every OA document file is stored in `.json` format, allowing any applications to process the content within. To present the data file in a human readable format, a renderer needs to be written.
+OA documents are both readable by machines as well as by humans. Every OA document file is stored in a `.json` format, allowing any application to process the content within. To present the data file in a human-readable format, a renderer needs to be written.
 
-In this guide, we will build and deploy the renderer to display data from a "Certificate of Completion".
+In this guide, we will build and deploy the renderer to display data from a 📜 Certificate of Completion.
 
 This renderer is a static website that will be embedded in compliant OA viewer. It will take in the OA document in the raw form and generates the corresponding HTML code for rendering.
 
-## Pre-requisite
+## Prerequisites
 
-- [git](https://git-scm.com/downloads)
-- [node.js](https://nodejs.org/en/download/)
-- [Github account](https://github.com/)
+- [Git](https://git-scm.com/downloads)
+- [Node.js](https://nodejs.org/en/download/)
+- [GitHub account](https://github.com/)
 - [Netlify account](https://www.netlify.com/)
-- [Basic react.js knowledge](https://reactjs.org/)
+- [Basic React.js and TypeScript knowledge](https://reactjs.org/)
 
 ## Clone Decentralized Renderer React Template
 
-A template for building your own document renderer has been created for you at https://github.com/Open-Attestation/decentralized-renderer-react-template.
+A template for building your own document renderer has been created for you at [our GitHub template repository](https://github.com/Open-Attestation/decentralized-renderer-react-template).
 
 ### Clone code repository locally
 
@@ -46,16 +46,16 @@ npm run storybook
 
 ![Default Story Book View](/docs/verifiable-document/document-template/default-storybook.png)
 
-After running the storybook, you should be able to see the default template provided at http://localhost:6006/.
+After running the Storybook, you should be able to see the default template provided at `http://localhost:6006/`.
 
 This is a live preview where you can see the changes when you:
 
-1. edit the raw document data in the "Knobs" tab
+1. edit the raw document data in the `Knobs` tab
 1. edit the template code to render the data
 
 ## Developing the renderer
 
-Now that we have set up the development environment, we can start writing our renderer. We will first define the data structure of our Certificate of Completion, followed by writing the renderer to render the HTML code corresponding to the data provided.
+Now that we have set up the development environment, we can start writing our renderer. We will first define the data structure of our 📜 Certificate of Completion, followed by writing the renderer to render the HTML code corresponding to the data provided.
 
 ### Update sample document data and type
 
@@ -84,27 +84,29 @@ export const customTemplateCertificate: CustomTemplateCertificate = {
 };
 ```
 
-In the above document data, you see three root objects:
+In the above OA document, you will see three root objects:
 
-### 1. \$template
+### 1. `$template`
 
-The `$template` key to describe the template name used to render this display.
+The `$template` key to describe the template name used to render this display. It should have the following keys:
 
-`$template.type` will always take the value of `EMBEDDED_RENDERER` for documents rendered in this manner.
+- `$template.name` is the name of the template used to render a given OA document. This allows a single document renderer to render for multiple types of OA documents; each with a different template name.
 
-`$template.name` is the name of the template used to render a given OA document. This allows a single document renderer to render for multiple types of OA documents; each with a different template name.
+- `$template.type` will always take the value of `EMBEDDED_RENDERER` for documents rendered in this manner.
 
-### 2. name
+- `$template.url` will be the remote URL where your OA decentralized renderer resides. For now, we set it to `https://localhost:3000` but we will change this value later on in the [Deploying Document Renderer](#deploying-document-renderer) section.
 
-The `name` key is a compulsory key to describe the type of OA document. In this case, we are creating a `OpenAttestation Tutorial Certificate of Completion`.
+### 2. `name`
 
-### 3. recipient
+The `name` key is a compulsory key to describe the type of OA document. In this case, we are creating an `OpenAttestation Tutorial Certificate of Completion`.
 
-OA documents do not have strict data structure and allows issuers of documents to define their own data schema. The `recipient` object is a user-defined object that describes who the certificate is conferred to. In this case, you may replace `John Doe` with your name.
+### 3. `recipient`
 
-In the next section, you will learn more about the OA document schema and how you may defined your own data structure, but for now, we will stick to this simple document data.
+OA documents do not have a strict data structure and allows issuers of documents to define their own data schema. The `recipient` object is a user-defined object that describes who the certificate is conferred to. In this case, you may replace `John Doe` with your name.
 
-### Registering the COC template
+In the next section, you will learn more about the OA document schema and how you may define your own data structure. For this guide, we will stick to this simple document.
+
+### Registering the COC template with `TemplateRegistry`
 
 `src/templates/index.tsx` is a file containing the configuration of all the templates available in this renderer.
 
@@ -121,11 +123,13 @@ export const registry: TemplateRegistry<any> = {
 };
 ```
 
-### Multiple views for a Template
+### Multiple views for a template
 
-An OA document may have multiple views, each of them rendered in a separate tabs. The views are defined in the configuration within the specific templates. In the repository, one view is declared in `src/templates/customTemplate/index.tsx` within the `templates` array variable.
+An OA document may have multiple views, each of them rendered in separate tabs. For example, an OA document that is a degree certificate may have the actual certificate as one view, and the transcript as another view in a single template. A demo with can be found at our [here](https://opencerts.io/?q={%22type%22:%22DOCUMENT%22,%22payload%22:{%22uri%22:%22https://opencerts.io/static/demo/mainnet.opencerts%22,%22permittedActions%22:[%22STORE%22],%22redirect%22:%22https://opencerts.io%22}}).
 
-For our Certificate of Completion, we will only use a single view. So we will remove any additional views and rename the first view's label as "Certificate".
+The views are defined in the configuration within the specific templates. In the repository, one view is declared in `src/templates/customTemplate/index.tsx` within the `templates` array variable.
+
+For our 📜 Certificate of Completion, we will only use a single view. So we will remove any additional views and rename the first view's label as `Certificate`.
 
 Replace the code in `src/templates/customTemplate/index.tsx` with the following:
 
@@ -143,11 +147,11 @@ export const templates = [
 
 ### Developing the COC Template View
 
-Finally, once all the components have been wired up, we may proceed to style our Certificate of Completion.
+Finally, once all the components have been wired up, we may proceed to style our 📜 Certificate of Completion.
 
 To change how the data is being renderered, we simply create a React component that takes in the raw document in the `document` props and render the corresponding HTML code.
 
-For our COC, we will simply display the following text:
+For our 📜 Certificate of Completion, we will simply display the following text:
 
 ```text
 OpenAttestation Tutorial Certificate of Completion
@@ -197,13 +201,13 @@ Now, your document renderer is ready to be built and deployed online.
 
 ## Deploying Document Renderer
 
-### Push code to github.com
+### Push code to GitHub
 
-Create a new repository in github and push the code to the new repository. For a step-by-step guide to import source code to github, you may read [this guide](https://help.github.com/en/github/importing-your-projects-to-github/adding-an-existing-project-to-github-using-the-command-line).
+Create a new repository in GitHub and push the code to the new repository. For a step-by-step guide to import source code to GitHub, you may read [this guide](https://help.github.com/en/github/importing-your-projects-to-github/adding-an-existing-project-to-github-using-the-command-line).
 
-### Deploy site from netlify.com
+### Deploy site onto Netlify
 
-Once you have your code on github.com, you may build and deploy the site from netlify.com.
+Once you have your code on GitHub, you may build and deploy the site onto [Netlify](https://netlify.com).
 
 ![Create a new site on netlify](/docs/verifiable-document/document-template/netlify-new.png)
 
@@ -215,14 +219,14 @@ On the build page, enter `npm run build` as the "Build command" and `dist` as th
 
 ![Sample Deployed URL](/docs/verifiable-document/document-template/netlify-deployed.png)
 
-Once the site has been deployed, you will obtain the url to the document renderer site. In the above example, the url is `https://frosty-joliot-c02c3d.netlify.com/`.
+Once the site has been deployed, you will obtain the URL to the document renderer site. In the above example, the URL is `https://frosty-joliot-c02c3d.netlify.com/`.
 
-Note that the website will be an empty page when viewed directly.
+Note that the website will be an empty page when viewed directly. This is normal because it is not meant to be viewed directly through a web browser.
 
-> Save the website url for future reference.
+> Save the website url for future reference. You should also update the `$template.url` in your OA document.
 
 ## Additional Note for Production Document Renderer
 
 It is recommended to use a custom domain you own for the document renderer website in production. This prevents locking in to any specific third party hosting provider.
 
-If you are using netlify, you may check out [how to enable custom domains](https://docs.netlify.com/domains-https/custom-domains/).
+If you are using Netlify, we recommend you to check out [how to enable custom domains](https://docs.netlify.com/domains-https/custom-domains/).

--- a/docs/verifiable-document/document-template.md
+++ b/docs/verifiable-document/document-template.md
@@ -53,9 +53,9 @@ This is a live preview where you can see the changes when you:
 1. edit the raw document data in the `Knobs` tab
 1. edit the template code to render the data
 
-## Developing the renderer
+## Developing the Document Renderer
 
-Now that we have set up the development environment, we can start writing our renderer. We will first define the data structure of our 📜 Certificate of Completion, followed by writing the renderer to render the HTML code corresponding to the data provided.
+Now that we have set up the development environment, we can start writing our document renderer. We will first define the data structure of our 📜 Certificate of Completion, followed by writing the renderer to render the HTML code corresponding to the data provided.
 
 ### Update sample document data and type
 
@@ -84,9 +84,11 @@ export const customTemplateCertificate: CustomTemplateCertificate = {
 };
 ```
 
+### Document objects explained
+
 In the above OA document, you will see three root objects:
 
-### 1. `$template`
+#### `$template`
 
 The `$template` key to describe the template name used to render this display. It should have the following keys:
 
@@ -96,11 +98,11 @@ The `$template` key to describe the template name used to render this display. I
 
 - `$template.url` will be the remote URL where your OA decentralized renderer resides. For now, we set it to `https://localhost:3000` but we will change this value later on in the [Deploying Document Renderer](#deploying-document-renderer) section.
 
-### 2. `name`
+#### `name`
 
 The `name` key is a compulsory key to describe the type of OA document. In this case, we are creating an `OpenAttestation Tutorial Certificate of Completion`.
 
-### 3. `recipient`
+#### `recipient`
 
 OA documents do not have a strict data structure and allows issuers of documents to define their own data schema. The `recipient` object is a user-defined object that describes who the certificate is conferred to. In this case, you may replace `John Doe` with your name.
 
@@ -221,7 +223,7 @@ On the build page, enter `npm run build` as the "Build command" and `dist` as th
 
 Once the site has been deployed, you will obtain the URL to the document renderer site. In the above example, the URL is `https://frosty-joliot-c02c3d.netlify.com/`.
 
-Note that the website will be an empty page when viewed directly. This is normal because it is not meant to be viewed directly through a web browser.
+Note that the website will be an empty page when viewed directly. **This is normal because it is not meant to be viewed directly through a web browser.**
 
 > Save the website url for future reference. You should also update the `$template.url` in your OA document.
 

--- a/docs/verifiable-document/document-template.md
+++ b/docs/verifiable-document/document-template.md
@@ -127,7 +127,7 @@ export const registry: TemplateRegistry<any> = {
 
 ### Multiple views for a template
 
-An OA document may have multiple views, each of them rendered in separate tabs. For example, an OA document that is a degree certificate may have the actual certificate as one view, and the transcript as another view in a single template. A demo with can be found [here](https://opencerts.io/?q={%22type%22:%22DOCUMENT%22,%22payload%22:{%22uri%22:%22https://opencerts.io/static/demo/mainnet.opencerts%22,%22permittedActions%22:[%22STORE%22],%22redirect%22:%22https://opencerts.io%22}}).
+An OA document may have multiple views, each of them rendered in separate tabs. For example, an OA document that is a degree certificate may have the actual certificate as one view, and the transcript as another view in a single template. A demo of the multiple views feature can be found [here](https://opencerts.io/?q={%22type%22:%22DOCUMENT%22,%22payload%22:{%22uri%22:%22https://opencerts.io/static/demo/mainnet.opencerts%22,%22permittedActions%22:[%22STORE%22],%22redirect%22:%22https://opencerts.io%22}}).
 
 The views are defined in the configuration within the specific templates. In the repository, one view is declared in `src/templates/customTemplate/index.tsx` within the `templates` array variable.
 

--- a/docs/verifiable-document/document-template.md
+++ b/docs/verifiable-document/document-template.md
@@ -127,7 +127,7 @@ export const registry: TemplateRegistry<any> = {
 
 ### Multiple views for a template
 
-An OA document may have multiple views, each of them rendered in separate tabs. For example, an OA document that is a degree certificate may have the actual certificate as one view, and the transcript as another view in a single template. A demo with can be found at our [here](https://opencerts.io/?q={%22type%22:%22DOCUMENT%22,%22payload%22:{%22uri%22:%22https://opencerts.io/static/demo/mainnet.opencerts%22,%22permittedActions%22:[%22STORE%22],%22redirect%22:%22https://opencerts.io%22}}).
+An OA document may have multiple views, each of them rendered in separate tabs. For example, an OA document that is a degree certificate may have the actual certificate as one view, and the transcript as another view in a single template. A demo with can be found at [here](https://opencerts.io/?q={%22type%22:%22DOCUMENT%22,%22payload%22:{%22uri%22:%22https://opencerts.io/static/demo/mainnet.opencerts%22,%22permittedActions%22:[%22STORE%22],%22redirect%22:%22https://opencerts.io%22}}).
 
 The views are defined in the configuration within the specific templates. In the repository, one view is declared in `src/templates/customTemplate/index.tsx` within the `templates` array variable.
 

--- a/docs/verifiable-document/document-template.md
+++ b/docs/verifiable-document/document-template.md
@@ -127,7 +127,7 @@ export const registry: TemplateRegistry<any> = {
 
 ### Multiple views for a template
 
-An OA document may have multiple views, each of them rendered in separate tabs. For example, an OA document that is a degree certificate may have the actual certificate as one view, and the transcript as another view in a single template. A demo with can be found at [here](https://opencerts.io/?q={%22type%22:%22DOCUMENT%22,%22payload%22:{%22uri%22:%22https://opencerts.io/static/demo/mainnet.opencerts%22,%22permittedActions%22:[%22STORE%22],%22redirect%22:%22https://opencerts.io%22}}).
+An OA document may have multiple views, each of them rendered in separate tabs. For example, an OA document that is a degree certificate may have the actual certificate as one view, and the transcript as another view in a single template. A demo with can be found [here](https://opencerts.io/?q={%22type%22:%22DOCUMENT%22,%22payload%22:{%22uri%22:%22https://opencerts.io/static/demo/mainnet.opencerts%22,%22permittedActions%22:[%22STORE%22],%22redirect%22:%22https://opencerts.io%22}}).
 
 The views are defined in the configuration within the specific templates. In the repository, one view is declared in `src/templates/customTemplate/index.tsx` within the `templates` array variable.
 

--- a/docs/verifiable-document/issuing-document.md
+++ b/docs/verifiable-document/issuing-document.md
@@ -15,7 +15,7 @@ In this guide, we will make use of a web application to issue the documents.
 
 ## Issuing via Web Application
 
-To issue the documents, we will use the application that we previously used when we created the document store smart contract: https://admin.tradetrust.io.
+To issue the documents, we will use the application that we previously used when we created the document store smart contract: <https://admin.tradetrust.io>.
 
 ![Issuing Interface](/docs/verifiable-document/issuing-document/issuing.png)
 

--- a/docs/verifiable-document/issuing-document.md
+++ b/docs/verifiable-document/issuing-document.md
@@ -8,7 +8,7 @@ After wrapping the documents and obtaining a merkle root, the documents are read
 
 In this guide, we will make use of a web application to issue the documents.
 
-## Pre-requisite
+## Prerequisites
 
 - Chrome browser
 - Metamask setup

--- a/docs/verifiable-document/overview.md
+++ b/docs/verifiable-document/overview.md
@@ -4,17 +4,17 @@ title: Verifiable Document Overview
 sidebar_label: Overview
 ---
 
-Verifiable documents form the core of the OpenAttestation (OA) Framework. In this quick start guide, you will be deploying your first verifiable document.
+Verifiable documents form the core of the OpenAttestation (OA) framework. In this quick start guide, you will be deploying your first verifiable document.
 
 ## Goal
 
 By the end of this guide, you would be able to create your 📜 Certificate of Completion that is valid on any OA Viewer connected to the Ethereum `ropsten` network.
 
-With these knowledge you will be able to create OA documents according to your own business needs by:
+With these knowledge, you will be able to create OA documents according to your own business needs by:
 
 1. Changing the data structure of the document to suit your needs
 1. Changing the rendering of the document to reflect your document styles
-1. Changing the backend to use Ethereum main network
+1. Changing the backend to use Ethereum `mainnet` network
 
 ## Overview of Components
 
@@ -22,15 +22,15 @@ With these knowledge you will be able to create OA documents according to your o
 
 ### Document Store Smart Contract
 
-When a document is being issued, a proof of the issuance is store onto the Ethereum blockchain. A smart contract is used to provide a globally consistent record for anyone to query a given document's issuance status.
+The document store is a smart contract deployed onto the Ethereum blockchain. When an OA document is issued, a proof of the issuance is stored onto the Ethereum blockchain through the smart contract. The smart contract is used to provide a globally consistent record for anyone to query a given OA document's issuance status.
 
 ### DNS Records
 
-A domain is required to issue an OA file. A DNS record must be inserted to the DNS to assert the identity of the OA document creator.
+A domain is required to issue an OA document. A DNS record must be inserted to the DNS to assert the identity of the OA document creator.
 
 ### Verifiable Document File
 
-Machine-readable data of the document is stored in a `.json` file. On top of the data, these files also contain information such as:
+A Verifiable Document File is also known as the OA document. Machine-readable data of the OA document is stored in a `.json` file. In addition to the data, these `.json` files also contain information such as:
 
 - claim of issuer's identity
 - document rendering information
@@ -38,4 +38,4 @@ Machine-readable data of the document is stored in a `.json` file. On top of the
 
 ### Decentralized Renderer
 
-The decentralized renderer gives the OA document a human readable look. It is essentially a website which will take an OA document data as input and display the document in a web view. This allows anyone to style their document without submitting code change to another party.
+The decentralized renderer gives the OA document a human-readable look. It is essentially a website which will take an OA document data as input and display the document in a web view. This allows anyone to style their document without submitting code change to another party.

--- a/docs/verifiable-document/overview.md
+++ b/docs/verifiable-document/overview.md
@@ -4,15 +4,15 @@ title: Verifiable Document Overview
 sidebar_label: Overview
 ---
 
-Verifiable documents form the core of the OpenAttestation(OA) Framework. In this quick start guide, you will be deploying your first verifiable document.
+Verifiable documents form the core of the OpenAttestation (OA) Framework. In this quick start guide, you will be deploying your first verifiable document.
 
 ## Goal
 
-By the end of this tutorial you would be able to create your "Certificate of Completion" that is valid on any OA Viewer connected to the Ethereum ropsten network.
+By the end of this guide, you would be able to create your 📜 Certificate of Completion that is valid on any OA Viewer connected to the Ethereum `ropsten` network.
 
 With these knowledge you will be able to create OA documents according to your own business needs by:
 
-1. Changing the data structure of the document to suite your needs
+1. Changing the data structure of the document to suit your needs
 1. Changing the rendering of the document to reflect your document styles
 1. Changing the backend to use Ethereum main network
 
@@ -30,7 +30,7 @@ A domain is required to issue an OA file. A DNS record must be inserted to the D
 
 ### Verifiable Document File
 
-Machine-readable data of the document is stored in a .json file. On top of the data, these files also contain information such as:
+Machine-readable data of the document is stored in a `.json` file. On top of the data, these files also contain information such as:
 
 - claim of issuer's identity
 - document rendering information

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[build]
+  ignore = "git diff --quiet HEAD^ HEAD .."

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -27,6 +27,6 @@
       "extension/verification-methods",
       "extension/identity-proofs"
     ],
-    "Appendix": ["appendix/ropsten-setup", "appendix/identity-wallet"]
+    "Appendix": ["appendix/ropsten-setup", "appendix/identity-wallet", "appendix/glossary"]
   }
 }


### PR DESCRIPTION
_Work in progress, creating an MR to view preview_

dns-proof.md
- added dns records example as a table
- added some links to dns txt setup guides for common domain registrar/dns providers

overview.md
- formatting, added emoji to Certificate of Completion 😄

document-template.md
- added explanation for `$template.url`, and a note to change the localhost URL to a remote URL (rationale: think some of us kinda forgot to do so when we tried it out during our first week)
- added explanation for multiple views in a template
- added example use case as well (and linked to existing OpenCerts example that has cert + transcript + video views) for clarity
- changed COC to Certificate of Completion, might be clearer to readers

issuing-document.md
- fixed bare URLs in markdown

in general (TBD)
- in-line codes and commands will be in `backticks`
- references to non-code like buttons/menu items in italics (?)