### PR TITLE
feat: status codes and errors

### DIFF
--- a/docs/appendix/status-codes-errors.md
+++ b/docs/appendix/status-codes-errors.md
@@ -1,0 +1,97 @@
+---
+id: status-codes-errors
+title: Status Codes and Errors
+sidebar_label: Status Codes and Errors
+---
+
+This document describes all verification status codes and errors returned by the [`@govtechsg/oa-verify`](https://github.com/Open-Attestation/oa-verify) package.
+
+## Status Codes and Errors
+
+Every error handled by the `oa-verify` package has an error `code` and `codeString` (which are provided in this [type definition](https://github.com/Open-Attestation/oa-verify/blob/master/src/types/error.ts)), so long as the particular verification fragment is not `VALID`.
+
+### `DOCUMENT_STATUS` Fragment
+
+This section details all status codes returned in the `DOCUMENT_STATUS` verification fragment. These error codes exist in both `OpenAttestationEthereumDocumentStoreStatusCode` and `OpenAttestationEthereumTokenRegistryStatusCode` unless otherwise stated.
+
+#### `UNEXPECTED_ERROR`
+
+| code | codeString          |
+|------|---------------------|
+| 0    | UNEXPECTED_ERROR    |
+
+#### `DOCUMENT_NOT_ISSUED`
+
+| code | codeString             |
+|------|------------------------|
+| 1    | DOCUMENT_NOT_ISSUED    |
+
+The document's merkle root cannot be found in the document store. Note that this error only exists in `OpenAttestationEthereumDocumentStoreStatusCode`.
+
+#### `DOCUMENT_NOT_MINTED`
+
+| code | codeString             |
+|------|------------------------|
+| 1    | DOCUMENT_NOT_MINTED    |
+
+The document's merkle root cannot be found in the token registry. Note that this error only exists in `OpenAttestationEthereumTokenRegistryStatusCode`.
+
+#### `CONTRACT_ADDRESS_INVALID`
+
+| code | codeString               |
+|------|--------------------------|
+| 2    | CONTRACT_ADDRESS_INVALID |
+
+The document store address provided is invalid, most likely because it's not of the correct length or it contains non-hexadecimal characters.
+
+#### `ETHERS_UNHANDLED_ERROR`
+
+| code | codeString             |
+|------|------------------------|
+| 3    | ETHERS_UNHANDLED_ERROR |
+
+This is an error that we have yet to handle it at this moment.
+
+#### `SKIPPED`
+
+| code | codeString |
+|------|------------|
+| 4    | SKIPPED    |
+
+#### `DOCUMENT_REVOKED`
+
+| code | codeString       |
+|------|------------------|
+| 5    | DOCUMENT_REVOKED |
+
+The document's merkle root has been revoked by the document store.
+
+#### `INVALID_ARGUMENT`
+
+| code | codeString       |
+|------|------------------|
+| 6    | INVALID_ARGUMENT |
+
+The document's merkle root is invalid because:
+
+- it is not of the correct length
+- it contains non-hexadecimal characters
+
+#### `CONTRACT_NOT_FOUND`
+
+| code | codeString         |
+|------|--------------------|
+| 404  | CONTRACT_NOT_FOUND |
+
+The document store address is of a valid format but cannot be found.
+
+#### `SERVER_ERROR`
+
+| code | codeString   |
+|------|--------------|
+| 500  | SERVER_ERROR |
+
+This error covers all non-HTTP 200 error codes. If you see this error, it's most likely because:
+
+- you are rate-limited by the Ethereum provider (e.g. `infura` or `cloudflare`) because of too many requests in a short period of time
+- the Ethereum provider is down

--- a/docs/appendix/status-codes-errors.md
+++ b/docs/appendix/status-codes-errors.md
@@ -20,6 +20,8 @@ This section details all status codes returned in the `DOCUMENT_STATUS` verifica
 |------|---------------------|
 | 0    | UNEXPECTED_ERROR    |
 
+This is an OpenAttestation error that we have yet to handle at this moment.
+
 #### `DOCUMENT_NOT_ISSUED`
 
 | code | codeString             |
@@ -50,7 +52,7 @@ The document store address provided is invalid, most likely because it's not of 
 |------|------------------------|
 | 3    | ETHERS_UNHANDLED_ERROR |
 
-This is an error that we have yet to handle it at this moment.
+This is an Ethers error that we have yet to handle at this moment.
 
 #### `SKIPPED`
 

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -40,7 +40,8 @@
       "appendix/ropsten-setup",
       "appendix/identity-wallet",
       "appendix/document-store-webapp",
-      "appendix/issuing-webapp"
+      "appendix/issuing-webapp",
+      "appendix/status-codes-errors"
     ]
   }
 }


### PR DESCRIPTION
In this MR, added the descriptions of status codes and errors for:

- DOCUMENT_STATUS Fragment
  - UNEXPECTED_ERROR
  - DOCUMENT_NOT_ISSUED
  - DOCUMENT_NOT_MINTED
  - CONTRACT_ADDRESS_INVALID
  - ETHERS_UNHANDLED_ERROR
  - SKIPPED
  - DOCUMENT_REVOKED
  - INVALID_ARGUMENT
  - CONTRACT_NOT_FOUND
  - SERVER_ERROR