### PR TITLE
docs: gas cost estimation updates

### DIFF
--- a/website/docs/docs-section/appendix/contract-costs.md
+++ b/website/docs/docs-section/appendix/contract-costs.md
@@ -153,7 +153,7 @@ export const PriceTable = (props) => {
   const priceFactor = (gwei / 10.0) * 0.000000001 * price;
   const { type } = props;
   const costData = contractGasData[type];
-  const currentDtStr = new Date().toLocaleString("en-UK", { timeZoneName: "short", month: "long", day: "numeric", year: "numeric" });
+  const currentDtStr = new Date().toLocaleString("en-UK", { timeZoneName: "short" });
   const rows = costData.map((record, idx) => (
     <tr key={idx}>
       <td>{record.name}</td>


### PR DESCRIPTION
## Summary
To update the gas cost estimation page with additional information as requested by Sin Yong.
Note that this PR is an update to #92 and based off from the new restructured docs layout in #93.

## Changes
* Add current date/time in the cost tables
* Indicate one-time deployments
* Indicate items that are applicable to DID
* Mention that verifiable docs can be issued in batches

