### PR TITLE
docs: cost comparisons for beta and polygon

### DIFF
--- a/website/docs/docs-section/appendix/savings-comparisons.mdx
+++ b/website/docs/docs-section/appendix/savings-comparisons.mdx
@@ -1,0 +1,161 @@
+---
+id: savings-comparisons
+title: Costs & Savings (Beta)
+sidebar_label: Costs & Savings (Beta)
+---
+
+import { FiatLabel } from "../../../src/components/FiatLabel";
+import { BoxTag } from "../../../src/components/BoxTag";
+import { useFetchGasCost } from "../../../src/hooks";
+
+If you are a new user of TradeTrust or are looking at deploying a new Token Registry (Transferable Documents), we suggest that you try out our new V4 beta version.
+Not only will you be able to try out the new features built in the new version, you will also enjoy massive cost savings when deploying your contracts!
+Here's an estimated breakdown of the differences in gas fees between the two versions and how much savings you can make when using the new V4 beta.
+
+<PriceTable type="transferable" />
+
+:::note
+The estimated gas may change along with the updates we have to the contracts. The current estimation is based on Document Store v2.2.3 and Token Registry v3.0.0.
+:::
+
+import { useState, useEffect } from "react";
+const contractGasData = {
+  transferable: [
+    {
+      name: "Token Deployment",
+      gas: {
+        v3: 3714024,
+        v4: 293687,
+      },
+      remarks: "One-time only"
+    },
+    {
+      name: "Issuance of Document",
+      gas: {
+        v3: 239523,
+        v4: 245051,
+      },
+    },
+    {
+      name: "Endorse Ownership",
+      gas: {
+        v3: 324688,
+        v4: 62470,
+      },
+      remarks: "Endorse both owners"
+    },
+    {
+      name: "Endorse Beneficiary",
+      gas: {
+        v3: 324688,
+        v4: 50330,
+      }
+    },
+    {
+      name: "Endorse Holdership",
+      gas: {
+        v3: 43634,
+        v4: 51323,
+      },
+    },
+    {
+      name: "Nominate Ownership",
+      gas: {
+        v3: 83225,
+        v4: 77859,
+      },
+      remarks: "Nominates both owners"
+    },
+    {
+      name: "Nominate Beneficiary",
+      gas: {
+        v3: 241463,
+        v4: 64717,
+      },
+    },
+    {
+      name: "Nominate Holder",
+      gas: {
+        v3: 241463,
+        v4: 49564,
+      },
+    },
+    {
+      name: "Surrender Document",
+      gas: {
+        v3: 93435,
+        v4: 84803,
+      },
+    },
+    {
+      name: "Restore Document",
+      gas: {
+        v3: 230980,
+        v4: 86924,
+      },
+    },
+    {
+      name: "Burn Document",
+      gas: {
+        v3: 66732,
+        v4: 90040,
+      },
+    },
+  ],
+};
+
+export const PriceTable = (props) => {
+  const { price, gwei } = useFetchGasCost(30000);
+  const priceFactor = (gwei / 10.0) * 0.000000001 * price;
+  const { type } = props;
+  const costData = contractGasData[type];
+  const currentDtStr = new Date().toLocaleString("en-SG", { hour12: true, timeZoneName: "short" });
+  const nf = new Intl.NumberFormat();
+  const rows = costData.map((record, idx) => {
+    const v3Gas = record.gas.v3;
+    const v4Gas = record.gas.v4;
+    const v3Cost = v3Gas * priceFactor;
+    const v4Cost = v4Gas * priceFactor;
+    const savings = (v4Cost - v3Cost);
+    return (
+      <tr key={idx}>
+        <td>{record.name}</td>
+        <td> {nf.format(v3Gas)}</td>
+        <td>{priceFactor === 0 ? <em>Calculating...</em> :
+          <FiatLabel>{v3Cost}</FiatLabel>}</td>
+        <td> {nf.format(v4Gas)}</td>
+        <td>{priceFactor === 0 ? <em>Calculating...</em> :
+          <FiatLabel>{v4Cost}</FiatLabel>}</td>
+        <td align="center"><FiatLabel>{savings}</FiatLabel>{savings <= 0 ? "🔻" : "🔺"}</td>
+        <td>{record.remarks || "-"}</td>
+      </tr>
+    );
+  });
+  return (
+    <div>
+      <p>
+        Estimations based on the current
+        gas <em>average</em> at <BoxTag>{gwei / 10.0} gwei</BoxTag> and ETH price
+        at USD <BoxTag><FiatLabel>{price}</FiatLabel></BoxTag> as at {currentDtStr}.
+      </p>
+      <table>
+        <thead>
+        <tr>
+          <th rowSpan="2">Action</th>
+          <th colSpan="2">V3.x</th>
+          <th colSpan="2">V4 Beta</th>
+          <th rowSpan="2">Savings (USD)</th>
+          <th rowSpan="2">Remarks</th>
+        </tr>
+        <tr>
+          <th>Est. Gas</th>
+          <th>Fiat (USD)</th>
+          <th>Est. Gas</th>
+          <th>Fiat (USD)</th>
+        </tr>
+        </thead>
+        <tbody>{rows}</tbody>
+      </table>
+    </div>
+  );
+};

--- a/website/docs/docs-section/appendix/savings-comparisons.mdx
+++ b/website/docs/docs-section/appendix/savings-comparisons.mdx
@@ -28,7 +28,7 @@ Please report any issues or suggestions [here](https://github.com/Open-Attestati
 :::note
 Note that the following estimation is _not_ a comprehensive list of all the costs involved and should be used as a reference only.
 
-The live gas fees and prices on this page are updated every 15s. Data are retrieved from [ETHGasStation](https://ethgasstation.info/), [Polygon Gas Station](https://polygon.technology) and [CryptoCompare](https://www.cryptocompare.com/).
+The live gas fees and prices on this page are updated every 15s. Data are retrieved from [BlockNative Gas Estimator](https://www.blocknative.com/gas-estimator), [Polygon Gas Station](https://polygon.technology) and [CryptoCompare](https://www.cryptocompare.com/).
 :::
 
 ## Estimated Fees on Ethereum
@@ -47,7 +47,7 @@ const contractGasData = {
       name: "Token Deployment (Quick Start)",
       gas: {
         v3: 3714024,
-        v4: 293687,
+        v4: 298757,
       },
       remarks: "One-time only"
     },
@@ -55,7 +55,7 @@ const contractGasData = {
       name: "Issuance of Document",
       gas: {
         v3: 239523,
-        v4: 245051,
+        v4: 245089,
       },
     },
     {
@@ -84,7 +84,7 @@ const contractGasData = {
       name: "Nominate Ownership",
       gas: {
         v3: 83225,
-        v4: 77859,
+        v4: 77858,
       },
       remarks: "Nominates both owners"
     },
@@ -113,21 +113,21 @@ const contractGasData = {
       name: "Restore Document",
       gas: {
         v3: 230980,
-        v4: 86924,
+        v4: 86586,
       },
     },
     {
       name: "Burn Document",
       gas: {
         v3: 66732,
-        v4: 90040,
+        v4: 89698,
       },
     },
     {
       name: "Token Deployment (Standalone)",
       gas: {
         v3: 3714024,
-        v4: 2342918,
+        v4: 2248797,
       },
       remarks: "For advanced usage"
     },
@@ -135,7 +135,7 @@ const contractGasData = {
       name: "Title Escrow Factory (Advanced)",
       gas: {
         v3: 0,
-        v4: 1660988,
+        v4: 1607041,
       },
       remarks: "New in V4"
     },

--- a/website/docs/docs-section/appendix/savings-comparisons.mdx
+++ b/website/docs/docs-section/appendix/savings-comparisons.mdx
@@ -49,7 +49,7 @@ const contractGasData = {
         v3: 3714024,
         v4: 298757,
       },
-      remarks: <>With <a href="#" target="_blank">Quick Start</a> deployment in v4</>
+      remarks: <>With <a href="https://github.com/Open-Attestation/token-registry/tree/beta#quick-start" target="_blank">Quick Start</a> deployment in v4</>
     },
     {
       name: "Issuance of Document",
@@ -129,7 +129,7 @@ const contractGasData = {
         v3: 3714024,
         v4: 2248797,
       },
-      remarks: <>For <a href="#" target="_blank">standalone</a> deployment in v4 (optional)</>
+      remarks: <>For <a href="https://github.com/Open-Attestation/token-registry/tree/beta#stand-alone-contract" target="_blank">standalone</a> deployment in v4 (optional)</>
     },
     {
       name: "Title Escrow Factory (Optional)",
@@ -184,7 +184,7 @@ export const PriceTable = ({ type, chain, priceFormatOptions }) => {
           <th rowSpan="2">Action</th>
           <th colSpan="2">V3.x</th>
           <th colSpan="2">V4 Beta</th>
-          <th rowSpan="2">Savings (USD)</th>
+          <th rowSpan="2">Fiat Difference (USD)</th>
           <th rowSpan="2">Remarks</th>
         </tr>
         <tr>

--- a/website/docs/docs-section/appendix/savings-comparisons.mdx
+++ b/website/docs/docs-section/appendix/savings-comparisons.mdx
@@ -124,17 +124,18 @@ const contractGasData = {
       },
     },
     {
-      name: "Token Deployment (Advanced)",
+      name: "Token Deployment (Standalone)",
       gas: {
         v3: 3714024,
         v4: 2342918,
       },
+      remarks: "For advanced usage"
     },
     {
       name: "Title Escrow Factory (Advanced)",
       gas: {
         v3: 0,
-        v4: 2342918,
+        v4: 1660988,
       },
       remarks: "New in V4"
     },

--- a/website/docs/docs-section/appendix/savings-comparisons.mdx
+++ b/website/docs/docs-section/appendix/savings-comparisons.mdx
@@ -8,21 +8,43 @@ import { FiatLabel } from "../../../src/components/FiatLabel";
 import { BoxTag } from "../../../src/components/BoxTag";
 import { useFetchGasCost } from "../../../src/hooks";
 
-If you are a new user of TradeTrust or are looking at deploying a new Token Registry (Transferable Documents), we suggest that you try out our new V4 beta version.
-Not only will you be able to try out the new features built in the new version, you will also enjoy massive cost savings when deploying your contracts!
-Here's an estimated breakdown of the differences in gas fees between the two versions and how much savings you can make when using the new V4 beta.
+Are you a new user of TradeTrust or looking at deploying a new Token Registry (Transferable Documents)? If you are, we'd totally suggest that you try out our new V4 beta version!
 
-<PriceTable type="transferable" />
+Not only will you be able to try out the new features in the beta version, you will also enjoy massive cost savings when deploying your contracts!
+This page gives an estimated breakdown of the differences in gas fees between the two versions and how much savings you can make when using the new V4 beta.
+
+The V4 beta contracts can help to save up to about 92% in total gas fees compared to its previous versions.
+If the costs on Ethereum is still a concern despite the savings, you can consider deploying onto the Polygon network, which the beta repository comes preconfigured with.
+The estimations are provided based on the current prices on the Ethereum and Polygon mainnet.
+
+Now, if you are convinced to try our beta, check out our beta repository [here](https://github.com/Open-Attestation/token-registry/tree/beta)! 🎉
+
+:::warning
+The beta versions are in active development. Please expect bugs and breaking changes along the way. Be warned but be brave!💪
+
+Please report any issues or suggestions [here](https://github.com/Open-Attestation/token-registry/issues).
+:::
 
 :::note
-The estimated gas may change along with the updates we have to the contracts. The current estimation is based on Document Store v2.2.3 and Token Registry v3.0.0.
+Note that the following estimation is _not_ a comprehensive list of all the costs involved and should be used as a reference only.
+
+The live gas fees and prices on this page are updated every 15s. Data are retrieved from [ETHGasStation](https://ethgasstation.info/), [Polygon Gas Station](https://polygon.technology) and [CryptoCompare](https://www.cryptocompare.com/).
 :::
+
+## Estimated Fees on Ethereum
+
+<PriceTable type="transferable" chain="ethereum" />
+
+## Estimated Fees on Polygon
+
+<PriceTable type="transferable" chain="polygon" priceFormatOptions={{maximumSignificantDigits: 3, minimumFractionDigits: 2}} />
+
 
 import { useState, useEffect } from "react";
 const contractGasData = {
   transferable: [
     {
-      name: "Token Deployment",
+      name: "Token Deployment (Quick Start)",
       gas: {
         v3: 3714024,
         v4: 293687,
@@ -101,13 +123,27 @@ const contractGasData = {
         v4: 90040,
       },
     },
+    {
+      name: "Token Deployment (Advanced)",
+      gas: {
+        v3: 3714024,
+        v4: 2342918,
+      },
+    },
+    {
+      name: "Title Escrow Factory (Advanced)",
+      gas: {
+        v3: 0,
+        v4: 2342918,
+      },
+      remarks: "New in V4"
+    },
   ],
 };
 
-export const PriceTable = (props) => {
-  const { price, gwei } = useFetchGasCost(30000);
-  const priceFactor = (gwei / 10.0) * 0.000000001 * price;
-  const { type } = props;
+export const PriceTable = ({ type, chain, priceFormatOptions }) => {
+  const { price, gwei } = useFetchGasCost(chain, 15000);
+  const priceFactor = gwei * 0.000000001 * price;
   const costData = contractGasData[type];
   const currentDtStr = new Date().toLocaleString("en-SG", { hour12: true, timeZoneName: "short" });
   const nf = new Intl.NumberFormat();
@@ -116,17 +152,20 @@ export const PriceTable = (props) => {
     const v4Gas = record.gas.v4;
     const v3Cost = v3Gas * priceFactor;
     const v4Cost = v4Gas * priceFactor;
-    const savings = (v4Cost - v3Cost);
+    const savings = v4Cost - v3Cost;
     return (
       <tr key={idx}>
         <td>{record.name}</td>
-        <td> {nf.format(v3Gas)}</td>
+        <td> {v3Gas ? nf.format(v3Gas) : "N.A."}</td>
         <td>{priceFactor === 0 ? <em>Calculating...</em> :
-          <FiatLabel>{v3Cost}</FiatLabel>}</td>
-        <td> {nf.format(v4Gas)}</td>
+          <FiatLabel {...priceFormatOptions}>{v3Cost || "0"}</FiatLabel>}</td>
+        <td> {v4Gas ? nf.format(v4Gas) : "N.A."}</td>
         <td>{priceFactor === 0 ? <em>Calculating...</em> :
-          <FiatLabel>{v4Cost}</FiatLabel>}</td>
-        <td align="center"><FiatLabel>{savings}</FiatLabel>{savings <= 0 ? "🔻" : "🔺"}</td>
+          <FiatLabel {...priceFormatOptions}>{v4Cost}</FiatLabel>}</td>
+        <td align="center">
+            {!v3Gas ? "–" : <FiatLabel {...priceFormatOptions}>{savings}</FiatLabel>}
+            {!v3Gas ? null : savings <= 0 ? "🔻" : "🔺"}
+        </td>
         <td>{record.remarks || "-"}</td>
       </tr>
     );
@@ -135,7 +174,7 @@ export const PriceTable = (props) => {
     <div>
       <p>
         Estimations based on the current
-        gas <em>average</em> at <BoxTag>{gwei / 10.0} gwei</BoxTag> and ETH price
+        gas <em>average</em> at <BoxTag>{Math.ceil(gwei)} gwei</BoxTag> and ETH price
         at USD <BoxTag><FiatLabel>{price}</FiatLabel></BoxTag> as at {currentDtStr}.
       </p>
       <table>

--- a/website/docs/docs-section/appendix/savings-comparisons.mdx
+++ b/website/docs/docs-section/appendix/savings-comparisons.mdx
@@ -47,7 +47,7 @@ const contractGasData = {
       name: "Token Deployment (Quick Start)",
       gas: {
         v3: 3714024,
-        v4: 298757,
+        v4: 301065,
       },
       remarks: <>With <a href="https://github.com/Open-Attestation/token-registry/tree/beta#quick-start" target="_blank">Quick Start</a> deployment in v4</>
     },
@@ -55,79 +55,64 @@ const contractGasData = {
       name: "Issuance of Document",
       gas: {
         v3: 239523,
-        v4: 245089,
+        v4: 250509,
       },
-    },
-    {
-      name: "Endorse Ownership",
-      gas: {
-        v3: 324688,
-        v4: 62470,
-      },
-      remarks: "Endorse both owners"
     },
     {
       name: "Endorse Beneficiary",
       gas: {
         v3: 324688,
-        v4: 50330,
+        v4: 52057,
       }
     },
     {
-      name: "Endorse Holdership",
+      name: "Transfer Holdership",
       gas: {
         v3: 43634,
-        v4: 51323,
+        v4: 47282,
       },
+    },
+    {
+      name: "Transfer Ownership",
+      gas: {
+        v3: 324688,
+        v4: 61333,
+      },
+      remarks: "Both beneficiary & holder"
     },
     {
       name: "Nominate Ownership",
       gas: {
         v3: 83225,
-        v4: 77858,
-      },
-      remarks: "Nominates both owners"
-    },
-    {
-      name: "Nominate Beneficiary",
-      gas: {
-        v3: 241463,
-        v4: 64717,
-      },
-    },
-    {
-      name: "Nominate Holder",
-      gas: {
-        v3: 241463,
-        v4: 49564,
-      },
+        v4: 47320,
+      }
     },
     {
       name: "Surrender Document",
       gas: {
         v3: 93435,
-        v4: 84803,
+        v4: 84586,
       },
     },
     {
       name: "Restore Document",
       gas: {
         v3: 230980,
-        v4: 86586,
+        v4: 92043,
       },
     },
     {
       name: "Burn Document",
       gas: {
         v3: 66732,
-        v4: 89698,
+        v4: 94795,
       },
     },
     {
       name: "Token Deployment (Standalone)",
       gas: {
         v3: 3714024,
-        v4: 2248797,
+        v4: 2251821,
       },
       remarks: <>For <a href="https://github.com/Open-Attestation/token-registry/tree/beta#stand-alone-contract" target="_blank">standalone</a> deployment in v4 (optional)</>
     },
@@ -135,7 +120,7 @@ const contractGasData = {
       name: "Title Escrow Factory (Optional)",
       gas: {
         v3: 0,
-        v4: 1607041,
+        v4: 1459818,
       },
       remarks: "New in V4"
     },

--- a/website/docs/docs-section/appendix/savings-comparisons.mdx
+++ b/website/docs/docs-section/appendix/savings-comparisons.mdx
@@ -15,7 +15,7 @@ This page gives an estimated breakdown of the differences in gas fees between th
 
 The V4 beta contracts can help to save up to about 92% in total gas fees compared to its previous versions.
 If the costs on Ethereum is still a concern despite the savings, you can consider deploying onto the Polygon network, which the beta repository comes preconfigured with.
-The estimations are provided based on the current prices on the Ethereum and Polygon mainnet.
+The estimations on this page are based on the current prices on the Ethereum and Polygon mainnet.
 
 Now, if you are convinced to try our beta, check out our beta repository [here](https://github.com/Open-Attestation/token-registry/tree/beta)! 🎉
 

--- a/website/docs/docs-section/appendix/savings-comparisons.mdx
+++ b/website/docs/docs-section/appendix/savings-comparisons.mdx
@@ -49,7 +49,7 @@ const contractGasData = {
         v3: 3714024,
         v4: 298757,
       },
-      remarks: "One-time only"
+      remarks: <>With <a href="#" target="_blank">Quick Start</a> deployment in v4</>
     },
     {
       name: "Issuance of Document",
@@ -129,10 +129,10 @@ const contractGasData = {
         v3: 3714024,
         v4: 2248797,
       },
-      remarks: "For advanced usage"
+      remarks: <>For <a href="#" target="_blank">standalone</a> deployment in v4 (optional)</>
     },
     {
-      name: "Title Escrow Factory (Advanced)",
+      name: "Title Escrow Factory (Optional)",
       gas: {
         v3: 0,
         v4: 1607041,
@@ -167,7 +167,7 @@ export const PriceTable = ({ type, chain, priceFormatOptions }) => {
             {!v3Gas ? "–" : <FiatLabel {...priceFormatOptions}>{savings}</FiatLabel>}
             {!v3Gas ? null : savings <= 0 ? "🔻" : "🔺"}
         </td>
-        <td>{record.remarks || "-"}</td>
+        <td>{record.remarks || "–"}</td>
       </tr>
     );
   });

--- a/website/docs/docs-section/appendix/savings-comparisons.mdx
+++ b/website/docs/docs-section/appendix/savings-comparisons.mdx
@@ -1,7 +1,6 @@
 ---
 id: savings-comparisons
-title: Costs & Savings (Beta)
-sidebar_label: Costs & Savings (Beta)
+title: Token Registry V4 (Beta)
 ---
 
 import { FiatLabel } from "../../../src/components/FiatLabel";

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -16,7 +16,7 @@
     {
       "type": "category",
       "label": "Appendix",
-      "items": ["docs-section/appendix/glossary", "docs-section/appendix/contract-costs"]
+      "items": ["docs-section/appendix/glossary", "docs-section/appendix/contract-costs", "docs-section/appendix/savings-comparisons"]
     },
     "docs-section/faq",
     {

--- a/website/src/components/FiatLabel/index.jsx
+++ b/website/src/components/FiatLabel/index.jsx
@@ -1,11 +1,18 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 
 export const FiatLabel = ({ children, ...options }) => {
+  const [opacity, setOpacity] = useState(0);
+
+  useEffect(() => {
+    setOpacity(0);
+    setTimeout(() => setOpacity(1), 100);
+  }, [children]);
+
   const nf = new Intl.NumberFormat("en-US", {
     style: "currency",
     currency: "USD",
     ...options,
   });
   const res = nf.format(Number(children));
-  return <span>{res}</span>;
+  return <span key={children} style={{opacity, transition: 'opacity 1s ease-in'}}>{res}</span>;
 };

--- a/website/src/hooks/useFetchGasCost.js
+++ b/website/src/hooks/useFetchGasCost.js
@@ -2,16 +2,17 @@ import React, { useEffect, useState } from "react";
 import { useRefresh } from './useRefresh';
 
 const gasApi = {
-  ethereum: "https://www.ethgasstation.info/json/ethgasAPI.json",
+  ethereum: "https://blocknative-api.herokuapp.com/data",
   polygon: "https://gasstation-mainnet.matic.network/v2",
 };
 
 const parseGasRes = (chain, res) => {
   switch (chain) {
     case "ethereum":
-      return Number(res.average) / 10;
+      const estPrice = res.estimatedPrices[1];
+      return estPrice.price + estPrice.maxPriorityFeePerGas;
     case "polygon":
-      return res.standard.maxFee;
+      return res.fast.maxFee;
     default:
       return 0;
   }

--- a/website/src/hooks/useRefresh.js
+++ b/website/src/hooks/useRefresh.js
@@ -1,11 +1,21 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 export const useRefresh = (period) => {
   const [tick, setTick] = useState(0);
+  const isTabActive = useRef(true);
   if (period < 1) return undefined;
+
+  useEffect(() => {
+    const activeHandler = () => {
+      isTabActive.current = !document.hidden;
+    };
+    window.addEventListener("visibilitychange", activeHandler);
+    return () => window.removeEventListener("visibilitychange", activeHandler);
+  }, []);
+
   useEffect(() => {
     const interval = setInterval(() => {
-      setTick((tick) => tick + 1);
+      if (isTabActive.current) setTick((tick) => tick + 1);
     }, period);
     return () => clearInterval(interval);
   }, []);


### PR DESCRIPTION
## Summary
A page for showing the comparison in costs between the current version and beta, and also between Ethereum and Polygon.

- To eliminate (or at least reduce) the on-going concern of costs and gas fee complains
- To encourage people to start trying out the beta version
- For IMDA to use as supporting documentation for purchasing ethers as discussed in one of the sprints

## Issues
* https://www.pivotaltracker.com/story/show/182022232

