### PR TITLE
feat: dark mode for cost labels

### DIFF
--- a/website/src/components/BoxTag/index.jsx
+++ b/website/src/components/BoxTag/index.jsx
@@ -2,6 +2,7 @@ import React from "react";
 
 export const BoxTag = ({ children }) => (
   <span
+    className="box-tag"
     style={{
       borderRadius: "3px",
       backgroundColor: "#eee",

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -21,3 +21,9 @@ blockquote {
     background-color: #334756;
   }
 }
+
+[data-theme="dark"] .box-tag {
+  color: #d7d7d7;
+  background-color: rgb(50 50 50) !important;
+  border-color: rgb(70 70 70) !important;
+}


### PR DESCRIPTION
## Summary
Dark mode for cost labels. Changes taken from #126.

## Issues
* https://www.pivotaltracker.com/story/show/181661430

