### PR TITLE
fix: blockquote text color is not visible when system is in dark mode 

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -16,10 +16,8 @@ blockquote {
   background-color: #fffbeb;
 }
 
-@media (prefers-color-scheme: dark) {
-  blockquote {
-    background-color: #334756;
-  }
+[data-theme="dark"] blockquote {
+  background-color: #334756;
 }
 
 [data-theme="dark"] .box-tag {


### PR DESCRIPTION
<img width="1145" alt="image" src="https://user-images.githubusercontent.com/15277233/181728249-911f274c-d849-438b-a532-824322c35307.png">
