### PR TITLE
fix: position of distribution methods in faq

### DIFF
--- a/website/docs/docs-section/faq.md
+++ b/website/docs/docs-section/faq.md
@@ -4,22 +4,6 @@ title: FAQ
 sidebar_label: FAQ
 ---
 
-#### How can I have an estimation of the costs involved in using the smart contracts ?
-
-You can refer to the page [Contract Costs](/docs/docs-section/appendix/contract-costs) for a breakdown of the estimations.
-
-#### What is gas ?
-
-For more information on Gas and Gas Prices, check out [this article](https://ethereum.stackexchange.com/questions/3/what-is-meant-by-the-term-gas)
-
-#### What is the theoretical storage limit of a smart contract?
-
-It is `2^261` bytes. Check out this stackoverflow [post](https://ethereum.stackexchange.com/questions/1038/is-there-a-theoretical-limit-for-amount-of-data-that-a-contract-can-store/1040#1040) for more information.
-
-#### Can I create multiple TXT records under the same domain/subdomain?
-
-Yes. You can make use of multiple TXT records to point to multiple Ethereum addresses (e.g. document stores or DIDs). Keep in mind each TXT record should only contain one Ethereum address record.
-
 #### What are OpenAttestation documents?
 
 OpenAttestation documents are verifiable documents, or Verifiable Credentials, as commonly referred to by the tech community. 
@@ -119,4 +103,20 @@ Below are the pros and cons of each approach.
         </tr>
     </tbody>
 </table>
+
+#### How can I have an estimation of the costs involved in using the smart contracts ?
+
+You can refer to the page [Contract Costs](/docs/docs-section/appendix/contract-costs) for a breakdown of the estimations.
+
+#### What is gas ?
+
+For more information on Gas and Gas Prices, check out [this article](https://ethereum.stackexchange.com/questions/3/what-is-meant-by-the-term-gas)
+
+#### What is the theoretical storage limit of a smart contract?
+
+It is `2^261` bytes. Check out this stackoverflow [post](https://ethereum.stackexchange.com/questions/1038/is-there-a-theoretical-limit-for-amount-of-data-that-a-contract-can-store/1040#1040) for more information.
+
+#### Can I create multiple TXT records under the same domain/subdomain?
+
+Yes. You can make use of multiple TXT records to point to multiple Ethereum addresses (e.g. document stores or DIDs). Keep in mind each TXT record should only contain one Ethereum address record.
 


### PR DESCRIPTION
## What
Shift position of the distribution methods in the FAQ to the top